### PR TITLE
Refactor `Jws` and `Jwt` Verification

### DIFF
--- a/packages/web5/lib/src/jws.dart
+++ b/packages/web5/lib/src/jws.dart
@@ -1,2 +1,3 @@
 export './jws/jws.dart';
+export './jws/decoded_jws.dart';
 export './jws/jws_header.dart';

--- a/packages/web5/lib/src/jws/decoded_jws.dart
+++ b/packages/web5/lib/src/jws/decoded_jws.dart
@@ -1,0 +1,66 @@
+import 'dart:typed_data';
+
+import 'package:web5/src/crypto.dart';
+import 'package:web5/src/jws/jws_header.dart';
+
+import 'package:web5/src/dids.dart';
+
+class DecodedJws {
+  final JwsHeader header;
+  final Uint8List payload;
+  final Uint8List signature;
+  final List<String> parts;
+
+  static final _didResolver =
+      DidResolver(methodResolvers: [DidJwk.resolver, DidDht.resolver]);
+
+  DecodedJws({
+    required this.header,
+    required this.payload,
+    required this.signature,
+    required this.parts,
+  });
+
+  Future<void> verify() async {
+    if (header.kid == null || header.alg == null) {
+      throw Exception(
+        'Malformed JWS. expected header to contain kid and alg.',
+      );
+    }
+
+    final dereferenceResult = await _didResolver.dereference(header.kid!);
+    if (dereferenceResult.hasError()) {
+      throw Exception(
+        'Verification failed. Failed to dereference kid. Error: ${dereferenceResult.dereferencingMetadata.error}',
+      );
+    }
+
+    final didResource = dereferenceResult.contentStream;
+    if (didResource == null) {
+      throw Exception(
+        'Verification failed. Expected header kid to dereference a verification method',
+      );
+    }
+
+    if (didResource is! DidVerificationMethod) {
+      throw Exception(
+        'Verification failed. Expected header kid to dereference a verification method',
+      );
+    }
+
+    final publicKeyJwk = didResource.publicKeyJwk;
+    final dsaName =
+        DsaName.findByAlias(algorithm: header.alg, curve: publicKeyJwk!.crv);
+
+    if (dsaName == null) {
+      throw Exception('${header.alg}:${publicKeyJwk.crv} not supported.');
+    }
+
+    await DsaAlgorithms.verify(
+      algName: dsaName,
+      publicKey: publicKeyJwk,
+      payload: payload,
+      signature: signature,
+    );
+  }
+}

--- a/packages/web5/lib/src/jws/jws.dart
+++ b/packages/web5/lib/src/jws/jws.dart
@@ -29,7 +29,7 @@ class Jws {
       header = JwsHeader.fromBase64Url(parts[0]);
     } on Exception {
       throw Exception(
-        'Malformed JWT. Invalid base64url encoding for JWT header',
+        'Malformed JWT. failed to decode header',
       );
     }
 
@@ -38,7 +38,7 @@ class Jws {
       payload = _base64UrlDecoder.convertNoPadding(parts[1]);
     } on Exception {
       throw Exception(
-        'Malformed JWT. Invalid base64url encoding for JWT payload',
+        'Malformed JWT. failed to decode claims',
       );
     }
 
@@ -47,7 +47,7 @@ class Jws {
       signature = base64.decoder.convertNoPadding(parts[2]);
     } on Exception {
       throw Exception(
-        'Malformed JWT. Invalid base64url encoding for JWT payload',
+        'Malformed JWT. faild to decode signature',
       );
     }
 

--- a/packages/web5/lib/src/jws/jws.dart
+++ b/packages/web5/lib/src/jws/jws.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:web5/src/dids.dart';
 import 'package:web5/src/crypto.dart';
-import 'package:web5/src/extensions.dart';
+import 'package:web5/src/dids.dart';
+import 'package:web5/src/extensions/base64url.dart';
+import 'package:web5/src/jws/decoded_jws.dart';
 import 'package:web5/src/jws/jws_header.dart';
 
 final _base64UrlCodec = Base64Codec.urlSafe();
@@ -13,6 +14,50 @@ final _base64UrlDecoder = _base64UrlCodec.decoder;
 class Jws {
   static final _didResolver =
       DidResolver(methodResolvers: [DidJwk.resolver, DidDht.resolver]);
+
+  static DecodedJws decode(String jws) {
+    final parts = jws.split('.');
+
+    if (parts.length != 3) {
+      throw Exception(
+        'Malformed JWT. expected 3 parts. got ${parts.length}',
+      );
+    }
+
+    final JwsHeader header;
+    try {
+      header = JwsHeader.fromBase64Url(parts[0]);
+    } on Exception {
+      throw Exception(
+        'Malformed JWT. Invalid base64url encoding for JWT header',
+      );
+    }
+
+    final Uint8List payload;
+    try {
+      payload = _base64UrlDecoder.convertNoPadding(parts[1]);
+    } on Exception {
+      throw Exception(
+        'Malformed JWT. Invalid base64url encoding for JWT payload',
+      );
+    }
+
+    final Uint8List signature;
+    try {
+      signature = base64.decoder.convertNoPadding(parts[2]);
+    } on Exception {
+      throw Exception(
+        'Malformed JWT. Invalid base64url encoding for JWT payload',
+      );
+    }
+
+    return DecodedJws(
+      header: header,
+      payload: payload,
+      signature: signature,
+      parts: parts,
+    );
+  }
 
   /// Signs a JWT payload using a specified [Did] and returns the signed JWT.
   ///
@@ -71,86 +116,13 @@ class Jws {
     }
   }
 
-  static Future<void> verify(String compactJws, {Uint8List? payload}) async {
-    final splitJws = compactJws.split('.');
-
-    if (splitJws.length != 3) {
-      throw Exception(
-        'Malformed JWS. expected 3 parts. got ${splitJws.length}',
-      );
-    }
-
-    final [
-      base64UrlEncodedHeader,
-      base64UrlEncodedPayload,
-      base64UrlEncodedSignature
-    ] = splitJws;
-
-    final JwsHeader header;
+  static Future<DecodedJws> verify(String jws) async {
     try {
-      header = JwsHeader.fromBase64Url(base64UrlEncodedHeader);
-    } on Exception {
-      throw Exception(
-        'Malformed JWS. Invalid base64url encoding for JWS header',
-      );
+      final decodedJws = decode(jws);
+      await decodedJws.verify();
+      return decodedJws;
+    } on Exception catch (e) {
+      throw Exception('Verification failed. $e');
     }
-
-    if (header.kid == null || header.alg == null) {
-      throw Exception(
-        'Malformed JWS. expected header to contain kid and alg.',
-      );
-    }
-
-    try {
-      payload ??= _base64UrlDecoder.convertNoPadding(base64UrlEncodedPayload);
-    } on Exception {
-      throw Exception(
-        'Malformed JWS. Invalid base64url encoding for JWS payload',
-      );
-    }
-
-    final Uint8List signature;
-    try {
-      signature = _base64UrlDecoder.convertNoPadding(base64UrlEncodedSignature);
-    } on Exception {
-      throw Exception(
-        'Malformed JWS. Invalid base64url encoding for JWS signature',
-      );
-    }
-
-    final dereferenceResult = await _didResolver.dereference(header.kid!);
-    if (dereferenceResult.hasError()) {
-      throw Exception(
-        'Verification failed. Failed to dereference kid. Error: ${dereferenceResult.dereferencingMetadata.error}',
-      );
-    }
-
-    final didResource = dereferenceResult.contentStream;
-    if (didResource == null) {
-      throw Exception(
-        'Verification failed. Expected header kid to dereference a verification method',
-      );
-    }
-
-    if (didResource is! DidVerificationMethod) {
-      throw Exception(
-        'Verification failed. Expected header kid to dereference a verification method',
-      );
-    }
-
-    final publicKeyJwk = didResource.publicKeyJwk;
-    final dsaName =
-        DsaName.findByAlias(algorithm: header.alg, curve: publicKeyJwk!.crv);
-
-    if (dsaName == null) {
-      throw Exception('${header.alg}:${publicKeyJwk.crv} not supported.');
-    }
-
-    return DsaAlgorithms.verify(
-      algName: dsaName,
-      publicKey: publicKeyJwk,
-      payload: payload,
-      signature: signature,
-    );
   }
 }

--- a/packages/web5/lib/src/jwt.dart
+++ b/packages/web5/lib/src/jwt.dart
@@ -1,5 +1,4 @@
 export './jwt/jwt.dart';
+export './jwt/decoded_jwt.dart';
 export './jwt/jwt_header.dart';
 export './jwt/jwt_claims.dart';
-export './jwt/jwt_decoded.dart';
-export './jwt/jwt_encoded.dart';

--- a/packages/web5/lib/src/jwt/decoded_jwt.dart
+++ b/packages/web5/lib/src/jwt/decoded_jwt.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:web5/src/jws/decoded_jws.dart';
+import 'package:web5/web5.dart';
+
+class DecodedJwt {
+  final JwtHeader header;
+  final JwtClaims claims;
+  final Uint8List signature;
+  final List<String> parts;
+
+  DecodedJwt({
+    required this.header,
+    required this.claims,
+    required this.signature,
+    required this.parts,
+  });
+
+  Future<void> verify() async {
+    final decodedJws = DecodedJws(
+      header: header,
+      payload: Base64Codec.urlSafe().decoder.convertNoPadding(parts[1]),
+      signature: signature,
+      parts: parts,
+    );
+
+    await decodedJws.verify();
+  }
+}

--- a/packages/web5/lib/src/jwt/jwt.dart
+++ b/packages/web5/lib/src/jwt/jwt.dart
@@ -1,86 +1,32 @@
 import 'dart:convert';
 
+import 'package:web5/src/dids.dart';
+import 'package:web5/src/extensions.dart';
+import 'package:web5/src/jws.dart';
 import 'package:web5/src/jws/jws.dart';
-import 'package:web5/src/dids/did.dart';
+import 'package:web5/src/jwt/decoded_jwt.dart';
 import 'package:web5/src/jwt/jwt_claims.dart';
-import 'package:web5/src/extensions/json.dart';
-import 'package:web5/src/jwt/jwt_decoded.dart';
-import 'package:web5/src/jwt/jwt_encoded.dart';
 import 'package:web5/src/jwt/jwt_header.dart';
 
-/**
- * TODO: refactor. awkward implementation:
- *   * Jwt.parse() returns an instance of Jwt but you can't call sign on an
- *     an instance of Jwt. Likely makes most sense for Jwt to have static methods
- *     only and potentially return something like ParsedJwt instead
- *   * Jwt.verify calls Jwt.parse first then calls Jws.verify which effectively
- *     performs the same logic as Jwt.parse
- */
-
-/// A utility class for handling
-/// [JSON Web Tokens (JWTs)](https://datatracker.ietf.org/doc/html/rfc7519)
-///
-/// This class provides functionalities to parse, encode, and sign JWTs.
-/// It supports JWT signing with DID keys.
 class Jwt {
-  JwtEncoded encoded;
-  JwtDecoded decoded;
+  static DecodedJwt decode(String jwt) {
+    final decodedJws = Jws.decode(jwt);
 
-  Jwt({required this.encoded, required this.decoded});
-
-  /// Parses a signed JWT string into its decoded form. returns both split
-  /// encoded and decoded forms
-  ///
-  /// Throws [Exception] if the JWT is malformed or if it does not meet
-  /// the expected structure and encoding requirements.
-  factory Jwt.parse(String signedJwt) {
-    final splitJwt = signedJwt.split('.');
-
-    if (splitJwt.length != 3) {
-      throw Exception(
-        'Malformed JWT. expected 3 parts. got ${splitJwt.length}',
-      );
-    }
-
-    final [
-      base64UrlEncodedHeader,
-      base64UrlEncodedPayload,
-      base64UrlEncodedSignature
-    ] = splitJwt;
-
-    final JwtHeader header;
+    final JwtClaims claims;
     try {
-      header = JwtHeader.fromBase64Url(base64UrlEncodedHeader);
-    } on Exception {
-      throw Exception(
-        'Malformed JWT. Invalid base64url encoding for JWT header',
-      );
-    }
-
-    if (header.typ == null || header.typ?.toUpperCase() != 'JWT') {
-      throw Exception('Expected JWT header to contain typ property set to JWT');
-    }
-
-    if (header.alg == null || header.kid == null) {
-      throw Exception('Expected JWT header to contain alg and kid');
-    }
-
-    final JwtClaims payload;
-    try {
-      payload = JwtClaims.fromBase64Url(base64UrlEncodedPayload);
+      final str = utf8.decode(decodedJws.payload);
+      claims = JwtClaims.fromJson(json.decode(str));
     } on Exception {
       throw Exception(
         'Malformed JWT. Invalid base64url encoding for JWT payload',
       );
     }
 
-    return Jwt(
-      decoded: JwtDecoded(header: header, payload: payload),
-      encoded: JwtEncoded(
-        header: base64UrlEncodedHeader,
-        payload: base64UrlEncodedPayload,
-        signature: base64UrlEncodedSignature,
-      ),
+    return DecodedJwt(
+      header: decodedJws.header,
+      claims: claims,
+      signature: decodedJws.signature,
+      parts: decodedJws.parts,
     );
   }
 
@@ -97,9 +43,9 @@ class Jwt {
     return Jws.sign(did: did, payload: payloadBytes, header: header);
   }
 
-  static Future<void> verify(String signedJwt) async {
-    Jwt.parse(signedJwt);
-
-    return Jws.verify(signedJwt);
+  static Future<DecodedJwt> verify(String jwt) async {
+    final decodedJwt = decode(jwt);
+    await decodedJwt.verify();
+    return decodedJwt;
   }
 }

--- a/packages/web5/test/jwt/jwt_test.dart
+++ b/packages/web5/test/jwt/jwt_test.dart
@@ -3,16 +3,16 @@ import 'package:test/test.dart';
 
 void main() {
   group('Jwt', () {
-    test('should parse signed JWT', () async {
+    test('should decode signed JWT', () async {
       final km = InMemoryKeyManager();
       final did = await DidJwk.create(keyManager: km);
 
       final signedJwt =
           await Jwt.sign(did: did, payload: JwtClaims(iss: did.uri));
 
-      final parsedJwt = Jwt.parse(signedJwt);
-      expect(parsedJwt.decoded.header.kid, contains('${did.uri}#'));
-      expect(parsedJwt.decoded.payload.iss, equals(did.uri));
+      final parsedJwt = Jwt.decode(signedJwt);
+      expect(parsedJwt.header.kid, contains('${did.uri}#'));
+      expect(parsedJwt.claims.iss, equals(did.uri));
     });
   });
 }


### PR DESCRIPTION
# Overview
Refactored `Jws` and `Jwt` Verification into two distinct operations: `Decode` and `Verify`

# Rationale
we've run into multiple scenarios where we need to:
1. verify a JWT or JWS _and then_ use a number of fields from within the header or the payload/claims
2. _decode_ a JWT or JWS, check some stuff within the payload or headers, _and then_ verify

The way in which `Jws` and `Jwt` were initially implemented doesn't let us do this. Additionally, the implementation was a bit obtuse as noted in the TODO [here](https://github.com/TBD54566975/web5-dart/blob/main/packages/web5/lib/src/jwt/jwt.dart#L11-L18)


# Changes

In order to remedy the above, this PR splits decoding and verifying into two distinct steps while still providing a single function call if desired


## Approach 1
This approach allows to caller to call verify and then decide to perform additional logic using the claims within a JWT depending on the result of verification

```dart
decodedJwt = await Jwt.verify('test');
```

## Approach 2
This approach requires the caller to first decode the JWT, perform whatever business logic is needed and then optionally call verify when desired

```dart
decodedJwt = Jwt.decode('test');
await decodedJwt.verify();
```

the `Jws` public api surface is identical. Simply change `Jwt` to `Jws` in the examples above.

> [!WARNING]
> this PR doesn't include enough tests. looking to add some ASAP