### PR TITLE
implement detached JWS verification

### DIFF
--- a/packages/web5/test/jws/jws_test.dart
+++ b/packages/web5/test/jws/jws_test.dart
@@ -1,0 +1,21 @@
+import 'dart:typed_data';
+
+import 'package:web5/web5.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Jws', () {
+    test('should successfuly sign & verify detached compact jws', () async {
+      final did = await DidJwk.create();
+      final payload = Uint8List.fromList('hello'.codeUnits);
+      final compactJws =
+          await Jws.sign(did: did, payload: payload, detachedPayload: true);
+
+      final parts = compactJws.split('.');
+      expect(parts.length, equals(3));
+      expect(parts[1], equals(''));
+
+      expect(Jws.verify(compactJws, detachedPayload: payload), completes);
+    });
+  });
+}


### PR DESCRIPTION
# Summary
Includes ability to verify a compact JWS with [detached content](https://datatracker.ietf.org/doc/html/rfc7515#appendix-F)


## Usage

### Signing
```dart
  final did = await DidJwk.create();
  final payload = Uint8List.fromList('hello'.codeUnits);
  final compactJws = await Jws.sign(did: did, payload: payload, detachedPayload: true);

  print('compactJws: $compactJws');
```

### Verification
```dart
import 'dart:typed_data';

import 'package:web5/web5.dart';

void main() async {
  final did = await DidJwk.create();
  final payload = Uint8List.fromList('hello'.codeUnits);
  final compactJws = 'eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmhiR2NpT2lKRlpFUlRRU0lzSW10cFpDSTZJa05EWm5wS1NHRlhiVEpOZFZoeU9WTm9URmxXU1Voa1JEa3pla1pmWlZScFRGQXhTekJLYm1scFMxVWlMQ0pqY25ZaU9pSkZaREkxTlRFNUlpd2llQ0k2SWpsVVExTTFhMjUyYlMxV1VHSjVVM3BmUjNOdU1HUnZOakZCYWtab1pYaHdaVmRvYTJabFFYRldXSE1pZlEjMCJ9..BuGapDpbkU2cmGTK4A4rmvpcyf-O5-GiLjN7CHuEc7GGI-7pbrPUL-2zGQkfvPlqu_YjSFDJuo9lLYOuZaiOCw';

  final decodedJws = Jws.decode(compactJws, detachedPayload: payload);
}
```