### PR TITLE
fix: use `http` instead of `https`

### DIFF
--- a/packages/web5/lib/src/dids/did_web/did_web.dart
+++ b/packages/web5/lib/src/dids/did_web/did_web.dart
@@ -97,7 +97,7 @@ class DidWeb {
     }
 
     final String documentUrl = Uri.decodeFull(did.id.replaceAll(':', '/'));
-    Uri? didUri = Uri.tryParse('https://$documentUrl');
+    Uri? didUri = Uri.tryParse('http://$documentUrl');
 
     if (didUri == null) throw 'Unable to parse DID document Url $documentUrl';
 

--- a/packages/web5/test/dids/did_web_test.dart
+++ b/packages/web5/test/dids/did_web_test.dart
@@ -23,20 +23,12 @@ const validDidWebDocument = '''{
           {
             "id": "#linkeddomains",
             "type": "LinkedDomains",
-            "serviceEndpoint": {
-              "origins": [
-                "https://www.linkedin.com/"
-              ]
-            }
+            "serviceEndpoint": ["https://www.linkedin.com/"]
           },
           {
             "id": "#hub",
             "type": "IdentityHub",
-            "serviceEndpoint": {
-              "instances": [
-                "https://hub.did.msidentity.com/v1.0/658728e7-1632-412a-9815-fe53f53ec58b"
-              ]
-            }
+            "serviceEndpoint": ["https://hub.did.msidentity.com/v1.0/658728e7-1632-412a-9815-fe53f53ec58b"]
           }
         ],
         "verificationMethod": [
@@ -116,7 +108,7 @@ void main() {
       when(() => request.close()).thenAnswer((_) async => response);
       when(
         () => mockClient.getUrl(
-          Uri.parse('https://www.linkedin.com/.well-known/did.json'),
+          Uri.parse('http://www.linkedin.com/.well-known/did.json'),
         ),
       ).thenAnswer((_) async => request);
 
@@ -128,7 +120,7 @@ void main() {
 
       verify(
         () => mockClient
-            .getUrl(Uri.parse('https://www.linkedin.com/.well-known/did.json')),
+            .getUrl(Uri.parse('http://www.linkedin.com/.well-known/did.json')),
       );
     });
 
@@ -139,7 +131,7 @@ void main() {
       when(() => request.close()).thenAnswer((_) async => response);
       when(
         () => mockClient.getUrl(
-          Uri.parse('https://www.remotehost.com:8892/ingress/did.json'),
+          Uri.parse('http://www.remotehost.com:8892/ingress/did.json'),
         ),
       ).thenAnswer((_) async => request);
 
@@ -152,7 +144,7 @@ void main() {
 
       verify(
         () => mockClient.getUrl(
-          Uri.parse('https://www.remotehost.com:8892/ingress/did.json'),
+          Uri.parse('http://www.remotehost.com:8892/ingress/did.json'),
         ),
       );
     });


### PR DESCRIPTION
resolving `did:web` is failing in tbdex-dart's `tbdex_http_client` due to a handshake error, this pr creates a temporary fix to that error.