### PR TITLE
feat: support `did:web` https

### DIFF
--- a/packages/web5/lib/src/dids/did_web/did_web.dart
+++ b/packages/web5/lib/src/dids/did_web/did_web.dart
@@ -96,10 +96,16 @@ class DidWeb {
       return DidResolutionResult.withError(DidResolutionError.invalidDid);
     }
 
-    final String documentUrl = Uri.decodeFull(did.id.replaceAll(':', '/'));
-    Uri? didUri = Uri.tryParse('http://$documentUrl');
+    var resolutionUrl = Uri.decodeFull(did.id.replaceAll(':', '/'));
+    if (resolutionUrl.contains('localhost')) {
+      resolutionUrl = 'http://$resolutionUrl';
+    } else {
+      resolutionUrl = 'https://$resolutionUrl';
+    }
 
-    if (didUri == null) throw 'Unable to parse DID document Url $documentUrl';
+    var didUri = Uri.tryParse(resolutionUrl);
+
+    if (didUri == null) throw 'Unable to parse DID document Url $resolutionUrl';
 
     // If none was specified, use the default path.
     if (didUri.path.isEmpty) didUri = didUri.replace(path: '/.well-known');

--- a/packages/web5/test/dids/did_web_test.dart
+++ b/packages/web5/test/dids/did_web_test.dart
@@ -108,7 +108,7 @@ void main() {
       when(() => request.close()).thenAnswer((_) async => response);
       when(
         () => mockClient.getUrl(
-          Uri.parse('http://www.linkedin.com/.well-known/did.json'),
+          Uri.parse('https://www.linkedin.com/.well-known/did.json'),
         ),
       ).thenAnswer((_) async => request);
 
@@ -120,7 +120,7 @@ void main() {
 
       verify(
         () => mockClient
-            .getUrl(Uri.parse('http://www.linkedin.com/.well-known/did.json')),
+            .getUrl(Uri.parse('https://www.linkedin.com/.well-known/did.json')),
       );
     });
 
@@ -131,7 +131,7 @@ void main() {
       when(() => request.close()).thenAnswer((_) async => response);
       when(
         () => mockClient.getUrl(
-          Uri.parse('http://www.remotehost.com:8892/ingress/did.json'),
+          Uri.parse('https://www.remotehost.com:8892/ingress/did.json'),
         ),
       ).thenAnswer((_) async => request);
 
@@ -144,7 +144,7 @@ void main() {
 
       verify(
         () => mockClient.getUrl(
-          Uri.parse('http://www.remotehost.com:8892/ingress/did.json'),
+          Uri.parse('https://www.remotehost.com:8892/ingress/did.json'),
         ),
       );
     });


### PR DESCRIPTION
https://github.com/TBD54566975/web5-dart/pull/63 removed `https` support in favor of `http` for testing. this pr brings back support for both