### PR TITLE
feat: add `DidMethodResolver` subclasses 

### DIFF
--- a/packages/web5/lib/src/dids/did_dht/did_dht.dart
+++ b/packages/web5/lib/src/dids/did_dht/did_dht.dart
@@ -16,8 +16,6 @@ final Set<String> txtEntryNames = {'vm', 'auth', 'asm', 'agm', 'inv', 'del'};
 class DidDht {
   static const String methodName = 'dht';
 
-  static final resolver = DidMethodResolver(name: methodName, resolve: resolve);
-
   static Future<BearerDid> create({
     KeyManager? keyManager,
     List<String>? alsoKnownAs,
@@ -289,4 +287,13 @@ class DidDht {
 
     return DidResolutionResult(didDocument: didDocument);
   }
+}
+
+class DidDhtResolver extends DidMethodResolver {
+  @override
+  String get name => DidDht.methodName;
+
+  @override
+  Future<DidResolutionResult> resolve(Did did, {HttpClient? options}) async =>
+      DidDht.resolve(did, client: options);
 }

--- a/packages/web5/lib/src/dids/did_jwk/did_jwk.dart
+++ b/packages/web5/lib/src/dids/did_jwk/did_jwk.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:web5/src/crypto.dart';
 import 'package:web5/src/dids/did.dart';
@@ -17,8 +16,6 @@ import 'package:web5/src/dids/did_method_resolver.dart';
 /// [Specification](https://github.com/quartzjer/did-jwk/blob/main/spec.md)
 class DidJwk {
   static const String methodName = 'jwk';
-
-  static final resolver = DidMethodResolver(name: methodName, resolve: resolve);
 
   /// Creates a new `did:jwk`. Stores associated private key in provided
   /// key manager.
@@ -61,8 +58,7 @@ class DidJwk {
   /// an invalid [DidResolutionResult].
   ///
   /// Throws [FormatException] if the JWK parsing fails.
-  static Future<DidResolutionResult> resolve(Did did,
-      {HttpClient? client}) async {
+  static Future<DidResolutionResult> resolve(Did did) async {
     if (did.method != methodName) {
       return DidResolutionResult.withError(DidResolutionError.invalidDid);
     }
@@ -106,4 +102,13 @@ class DidJwk {
       capabilityDelegation: [verificationMethod.id],
     );
   }
+}
+
+class DidJwkResolver extends DidMethodResolver {
+  @override
+  String get name => DidJwk.methodName;
+
+  @override
+  Future<DidResolutionResult> resolve(Did did, {dynamic options}) async =>
+      DidJwk.resolve(did);
 }

--- a/packages/web5/lib/src/dids/did_method_resolver.dart
+++ b/packages/web5/lib/src/dids/did_method_resolver.dart
@@ -1,24 +1,19 @@
-import 'dart:io';
-
 import 'package:web5/src/dids/did.dart';
 import 'package:web5/src/dids/did_core.dart';
 
 /// Represents a method resolver for a specific DID method.
-class DidMethodResolver {
+abstract class DidMethodResolver {
   /// The name of the DID method e.g. jwk, dht, web
-  String name;
+  String get name;
 
   /// The function to resolve a DID URI using this method.
-  Future<DidResolutionResult> Function(Did, {HttpClient? client}) resolve;
-
-  /// Constructs a [DidMethodResolver] with a given [name] and [resolve] function.
-  DidMethodResolver({required this.name, required this.resolve});
+  Future<DidResolutionResult> resolve(Did did, {covariant dynamic options});
 
   Future<DidDereferenceResult> dereference(
     Did did, {
-    HttpClient? client,
+    dynamic options,
   }) async {
-    final didResolutionResult = await resolve(did, client: client);
+    final didResolutionResult = await resolve(did, options: options);
 
     if (didResolutionResult.hasError()) {
       return DidDereferenceResult.withError(

--- a/packages/web5/lib/src/dids/did_resolver.dart
+++ b/packages/web5/lib/src/dids/did_resolver.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:web5/src/dids/did.dart';
 import 'package:web5/src/dids/did_core.dart';
 import 'package:web5/src/dids/did_dht/did_dht.dart';
@@ -19,9 +17,9 @@ class DidResolver {
     // Register resolvers that we provide out of the box
     return DidResolver(
       methodResolvers: [
-        DidJwk.resolver,
-        DidDht.resolver,
-        DidWeb.resolver,
+        DidJwkResolver(),
+        DidDhtResolver(),
+        DidWebResolver(),
       ],
     );
   }
@@ -29,15 +27,15 @@ class DidResolver {
   // Static field to hold the instance
   static final DidResolver _instance = DidResolver._default();
 
-  static Future<DidResolutionResult> resolve(String uri, {HttpClient? client}) {
-    return _instance.resolveDid(uri, client: client);
+  static Future<DidResolutionResult> resolve(String uri, {dynamic options}) {
+    return _instance.resolveDid(uri, options: options);
   }
 
   static Future<DidDereferenceResult> dereference(
     String url, {
-    HttpClient? client,
+    dynamic options,
   }) {
-    return _instance.dereferenceDid(url, client: client);
+    return _instance.dereferenceDid(url, options: options);
   }
 
   /// Constructs a [DidResolver] with a list of [DidMethodResolver]s.
@@ -52,7 +50,7 @@ class DidResolver {
   /// Resolves a DID URI into a [DidResolutionResult].
   ///
   /// Throws an [Exception] if no resolver is available for the given method.
-  Future<DidResolutionResult> resolveDid(String uri, {HttpClient? client}) {
+  Future<DidResolutionResult> resolveDid(String uri, {dynamic options}) {
     final Did did;
     try {
       did = Did.parse(uri);
@@ -68,7 +66,7 @@ class DidResolver {
       throw Exception('no resolver available for did:${did.method}');
     }
 
-    return resolver.resolve(did, client: client);
+    return resolver.resolve(did, options: options);
   }
 
   /// Resolves a DID URI into a [DidResolutionResult].
@@ -76,7 +74,7 @@ class DidResolver {
   /// Throws an [Exception] if no resolver is available for the given method.
   Future<DidDereferenceResult> dereferenceDid(
     String url, {
-    HttpClient? client,
+    dynamic options,
   }) {
     final did = Did.parse(url);
     final resolver = methodResolvers[did.method];
@@ -85,6 +83,6 @@ class DidResolver {
       throw Exception('no resolver available for did:${did.method}');
     }
 
-    return resolver.dereference(did, client: client);
+    return resolver.dereference(did, options: options);
   }
 }

--- a/packages/web5/lib/src/dids/did_web/did_web.dart
+++ b/packages/web5/lib/src/dids/did_web/did_web.dart
@@ -10,11 +10,6 @@ import 'package:web5/src/dids/did_method_resolver.dart';
 class DidWeb {
   static const String methodName = 'web';
 
-  static final DidMethodResolver resolver = DidMethodResolver(
-    name: methodName,
-    resolve: resolve,
-  );
-
   static Future<BearerDid> create({
     required String url,
     AlgorithmId? algorithm,
@@ -125,4 +120,13 @@ class DidWeb {
 
     return DidResolutionResult(didDocument: doc);
   }
+}
+
+class DidWebResolver extends DidMethodResolver {
+  @override
+  String get name => DidWeb.methodName;
+
+  @override
+  Future<DidResolutionResult> resolve(Did did, {HttpClient? options}) =>
+      DidWeb.resolve(did, client: options);
 }


### PR DESCRIPTION
following https://github.com/TBD54566975/web5-dart/pull/64, this pr aims to remove the need for forcing `resolve()` functions in each did method to take an optional `HttpClient`