### PR TITLE
fix: make `BearerDid` null-safe

### DIFF
--- a/packages/web5/lib/src/dids/bearer_did.dart
+++ b/packages/web5/lib/src/dids/bearer_did.dart
@@ -40,8 +40,12 @@ class BearerDid {
     }
 
     final keyExporter = keyManager as KeyExporter;
-    for (final vm in document.verificationMethod!) {
-      final publicKeyJwk = vm.publicKeyJwk!;
+    for (final vm in document.verificationMethod ?? []) {
+      if (vm.publicKeyJwk == null) {
+        continue;
+      }
+
+      final publicKeyJwk = vm.publicKeyJwk;
       final keyId = publicKeyJwk.computeThumbprint();
       final jwk = await keyExporter.export(keyId);
 


### PR DESCRIPTION
closes https://github.com/TBD54566975/web5-dart/issues/73