### PR TITLE
did:dht bep44 seq should be seconds since epoch

### DIFF
--- a/packages/web5/lib/src/dids/did_dht/did_dht.dart
+++ b/packages/web5/lib/src/dids/did_dht/did_dht.dart
@@ -82,7 +82,7 @@ class DidDht {
         return await keyManager!.sign(keyAlias, data);
       }
 
-      final seq = DateTime.now().microsecondsSinceEpoch;
+      final seq = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       final message = await Bep44Message.create(dnsPacket.encode(), seq, sign);
 
       final gatewayUrl = Uri.parse('$gatewayUri/$id');


### PR DESCRIPTION
Spec says to use seconds since epoch, but we were using microseconds since epoch. https://did-dht.com/#create.
Thanks @decentralgabe for catching this in web5-rs https://github.com/TBD54566975/web5-rs/pull/209#discussion_r1600705798